### PR TITLE
File verification, Playlist export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,36 @@
 # itunesXMLtoM3U
-Convert iTunes XML library to an M3U playlist
+Scan iTunes XML libraries for file presence and integrity and export them to M3U playlists.
 
 ## Usage
 
-First, export your itunes library:
+Verify that your itunes library xml file is up to date, which is commonly ensured by itunes.
 
-Go to iTunes, then menu option: File > Library > Export Library
+If not, export it manually within itunes by calling the menu option File > Library > Export Library and selecting to "Export as XML" within the save file dialog.
 
-Select the option to "Export as XML", and then run this app like this:
 
-    node convert.js library.xml > library.m3u
+To dump all library items as m3u with basic extended information, run:
+
+    node convert.js /path/to/library.xml > library.m3u
 
 You will then have an M3U file of your library called library.m3u.
 
-The actual filenames are not used, instead they are anonymised into faux filenames using the album name etc.
+To scan all library items and verify them by means of ffmpeg, run:
 
-## Why import iTunes Libraries?
+	node scan.js (presence) (again) (continue) /path/to/library.xml
 
-You might want to move from Apple Music to Spotify or another platform.
+    presence: Only check whether files exist
+    continue: Continue interrupted scan
+    again: Re-Scan files previously marked as broken
+
+Following files are stored to the library's folder:
+
+    _all.m3u: Contains all scanned files
+    _failed.m3u / _failedagain.m3u: Contain files determined to be broken (again)
+
+To export all of the library's playlists (including master playlists by media type) as simple m3u files to the library's folder, run:
+
+    node export.js /path/to/library.xml
+
 
 ## Why M3U?
 
@@ -36,5 +49,3 @@ Soundiiz is available here: <https://soundiiz.com/converter>
 ## Why not just use [my favourite tool] ?
 
 I didn't find it in the 10 minutes I googled for a tool, and it didn't take me long to write this.
-
-

--- a/export.js
+++ b/export.js
@@ -36,8 +36,8 @@ for (var plId in itunes.Playlists) {
 		var curpl = [];
 
 		// Iterate over all playlist items if present
-		console.log('Exporting ' + pl.Name + ' (' + plfile + ')');
 		if (pl['Playlist Items'] && pl['Playlist Items'].length) {
+			console.log('Exporting ' + pl.Name + ' with ' + pl['Playlist Items'].length + ' items (' + plfile + ')');
 			for (var i = 0; i < pl['Playlist Items'].length; i++) {
 
 				// Determine playlist item track id
@@ -52,7 +52,8 @@ for (var plId in itunes.Playlists) {
 
 			// Flush playlist array as simple m3u
 			fs.writeFileSync(path.join(basepath, plfile), curpl.join('\n') + '\n', { flag: 'w+' });
-			
+		} else {
+			console.log('Skipping playlist ' + pl.Name + ' as it is empty');
 		}
 	} catch (e) {
 		console.log('Failed to export playlist (' + e + ')');

--- a/export.js
+++ b/export.js
@@ -1,0 +1,76 @@
+'use strict'
+var fs = require('fs')
+
+var plist = require('plist')
+var path = require('path')
+const { spawnSync } = require('child_process');
+
+if (process.argv.length < 3) {
+    console.log('Usage: node export.js [INPUT XML FILE]')
+    console.log('Outputs all available playlists as simple m3u to the folder of the xml file.')
+    process.exit(1)
+}
+
+var dolog = 1
+var ipath = ''
+var searchpath = 'iTunes Media'
+
+// Determine input and base path
+ipath = process.argv[process.argv.length - 1];
+var basepath = path.dirname(ipath)
+console.log('Base path: ' + basepath);
+
+// Load library and determine item count
+console.log('Loading library file...')
+var itunes = plist.parse(fs.readFileSync(ipath, 'utf8'))
+var allcount = Object.keys(itunes.Playlists).length
+console.log('Library loaded (' + allcount + ' playlists). Exporting playlists relative to ' + basepath + ' .')
+
+// Iterate over all playlists
+for (var plId in itunes.Playlists) {
+
+	try {
+		// Determine playlist (file) name
+		var pl = itunes.Playlists[plId];
+		var plfile = pl.Name.replace(/[/\\?%*:|"<>]/g, ' ') + '.m3u';
+		var curpl = [];
+
+		// Iterate over all playlist items if present
+		console.log('Exporting ' + pl.Name + ' (' + plfile + ')');
+		if (pl['Playlist Items'] && pl['Playlist Items'].length) {
+			for (var i = 0; i < pl['Playlist Items'].length; i++) {
+
+				// Determine playlist item track id
+				var trID = pl['Playlist Items'][i]['Track ID'];
+				if (trID) {
+					// Determine playlist item track path and store to array
+					var trLoc = trLocation(trID);
+					if (trLoc && trLoc.length) { curpl.push(trLoc); }
+				}
+
+			}
+
+			// Flush playlist array as simple m3u
+			fs.writeFileSync(path.join(basepath, plfile), curpl.join('\n') + '\n', { flag: 'w+' });
+			
+		}
+	} catch (e) {
+		console.log('Failed to export playlist (' + e + ')');
+	}
+}
+
+console.log('Exports completed.')
+process.exit(0)
+
+function trLocation(trID) {
+
+	// Unescape track location if it is a local file
+	var rpath = itunes.Tracks[trID].Location;
+	if (rpath && rpath.length && rpath.startsWith('file://')) {
+		rpath = decodeURIComponent(rpath);
+		rpath = rpath.substring(rpath.lastIndexOf(searchpath));
+	}
+	//console.log('	' + trID + ':' + rpath);
+	return rpath;
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,106 @@
+{
+  "name": "itunesXMLtoM3U",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "itunesXMLtoM3U",
+      "version": "1.0.0",
+      "license": "BSD2",
+      "dependencies": {
+        "plist": "^1.2.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
+    },
+    "node_modules/plist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+      "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "util-deprecate": "1.0.2",
+        "xmlbuilder": "4.0.0",
+        "xmldom": "0.1.x"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/xmlbuilder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+      "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
+      "dependencies": {
+        "lodash": "^3.5.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+      "engines": {
+        "node": ">=0.1"
+      }
+    }
+  },
+  "dependencies": {
+    "base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
+    },
+    "plist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
+      "integrity": "sha512-dL9Xc2Aj3YyBnwvCNuHmFl2LWvQacm/HEAsoVwLiuu0POboMChETt5wexpU1P6F6MnibIucXlVsMFFgNUT2IyA==",
+      "requires": {
+        "base64-js": "0.0.8",
+        "util-deprecate": "1.0.2",
+        "xmlbuilder": "4.0.0",
+        "xmldom": "0.1.x"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "xmlbuilder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
+      "integrity": "sha512-wrG9gc6hCFDd5STt+6fsjP2aGSkjkNSewH+1K6s0KVOd94vXAUyTwlxWVnMFVtLdMf+q0QRZN1z9hTOKgoEdMg==",
+      "requires": {
+        "lodash": "^3.5.0"
+      }
+    },
+    "xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,9 +16,17 @@
   },
   "keywords": [
     "itunes",
-    "m3u"
+    "m3u",
+    "verify",
+    "scan",
+    "file",
+    "corrupt",
+    "broken"
   ],
   "author": "Daniel Alexander Smith <daniel@danielsmith.eu> (https://danielsmith.eu/)",
+  "contributors": [
+    "Michael Hammes <gitresmh@icloud.com>"
+  ],
   "license": "BSD2",
   "bugs": {
     "url": "https://github.com/danielsmith-eu/itunesXMLtoM3U/issues"

--- a/scan.js
+++ b/scan.js
@@ -1,0 +1,199 @@
+'use strict'
+var fs = require('fs')
+var plist = require('plist')
+var path = require('path')
+const { spawnSync } = require('child_process');
+
+// Check argument count
+if (process.argv.length < 3) {
+    console.log('Usage: node scan.js [presence (of files only)] [again] [continue] [INPUT XML FILE]')
+    console.log('Scans file presence (and by default file integrity using ffmpeg) of given xml file.')    
+    process.exit(1)
+}
+
+// Search path by media folder naming convention
+const searchpath = 'iTunes Media'
+
+var ipath = ''	// Input path
+var rmode = 0	// Re-Evaluate
+var cmode = 0	// Continue
+var qmode = 0	// Presence only
+
+// Parse arguments
+for (var i=2; i<process.argv.length - 1; i++) {
+	switch (process.argv[i]) {
+		case 'presence': { qmode = 1; console.log('Only checking file presence.'); break; }
+		case 'continue': { cmode = 1; console.log('Continueing previous (re)scan.'); break; }
+		case 'again': { rmode = 1; cmode = 1; console.log('Re-evaluating known broken files.'); break; }
+	}
+}
+ipath = process.argv[process.argv.length - 1];
+
+// Notify if default mode
+if (!rmode) { console.log('Scanning xml library for broken files.'); }
+
+// Check ffmpeg presence if required
+if (!qmode) {
+	try {
+		const res = spawnSync('which', [ 'ffmpeg' ]); if (res.status) { throw 'ffmpegnotfound'; }
+	} catch (e) {
+		console.log('Unable to find ffmpeg which is required for testing files.'); process.exit(2);
+	}
+}
+
+// Determine base path
+var basepath = path.dirname(ipath)
+console.log('Base path: ' + basepath);
+
+// Set up buffers and counters
+var allsongs = []
+
+var failedsongs = []
+
+// Execute according to mode
+try {
+	if (cmode > 0) { plread(); }
+	if (!rmode) { itcheck(); } else { plcheck(); }
+} catch (e) {
+	console.log('(Re)scan failed: ' + e);
+	process.exit(3)
+}
+process.exit(0)
+
+function itcheck() {
+
+	// Load library and determine item count
+	console.log('Loading library file...')
+	var itunes = plist.parse(fs.readFileSync(ipath, 'utf8'))
+	var allcount = Object.keys(itunes.Tracks).length
+	console.log('Library loaded (' + allcount + ' tracks).')
+
+	// Set up counters
+	var curcount = 0
+	var failedcount = 0
+	var skipcount = allsongs.length
+	if (skipcount) { curcount = skipcount; console.log('Skipping ' + skipcount + ' tracks.'); }
+	console.log('')
+
+	// Iterate over all tracks
+	for (var trackID in itunes.Tracks) {
+		if (skipcount) { skipcount--; continue; } // Skip in continue mode
+
+		// Determine track path and process file if it is local
+		var track = itunes.Tracks[trackID]
+		var rpath = track.Location
+		if (rpath && rpath.startsWith('file://')) {
+			rpath = decodeURIComponent(track.Location); rpath = rpath.substring(rpath.lastIndexOf(searchpath));
+			var tpath = path.join(basepath, rpath)
+
+			// Check for presence
+			if (!fs.existsSync(tpath)) {
+				failedsongs.push(rpath); failedcount++;
+
+			} else if (!qmode) {
+				try { // Check for integrity failing on any kind of ffmpeg error
+					const res = spawnSync('ffmpeg', ['-v', 'error', '-i', tpath, '-f',  'null', '-']);
+					if (res.stderr.length) { throw res.stderr; }
+				} catch (e) {
+					failedsongs.push(rpath); failedcount++;
+				}
+			}
+		}
+
+		// Add to list of all items
+		allsongs.push(rpath)
+
+		// Count, notify status and flush regularly
+		curcount++;
+		if (curcount % 5 == 0) { dostatus(curcount, allcount, failedcount); }
+		if (curcount % (100 + (qmode * 900)) == 0) { plflush(failedcount); }
+	}
+
+	// Final flush and report
+	plflush(failedcount);
+	doreport(allcount, failedcount);
+}
+
+function plcheck() {
+	
+	console.log('Rechecking ' + failedsongs.length + ' failed songs...')
+
+	// Set up counters
+	var allcount = failedsongs.length;
+	var curcount = 0
+	var failedcount = 0
+	var newfailedsongs = []
+
+	// Iterate over all tracks determined to be broken
+	for (var i=0; i<failedsongs.length; i++) {
+		
+		var tpath = path.join(basepath, failedsongs[i])
+		try {
+			// Check for presence
+			if (!fs.existsSync(tpath)) { throw 'File not found (' + tpath + ')'; }
+
+			if (!qmode) { // Check for integrity
+				const res = spawnSync('ffmpeg', ['-v', 'error', '-i', tpath, '-f',  'null', '-']); //, '2>&1'
+				if (res && res.stderr.length) { throw res.stderr; }
+			}
+		} catch (e) {
+			// Add to list of tracks that are still broken
+			newfailedsongs.push(failedsongs[i])
+			failedcount++
+		}
+		curcount++;
+		if (curcount % 5 == 0) { dostatus(curcount, allcount, failedcount); }
+	}
+
+	// Update arrays, flush and report
+	failedsongs = newfailedsongs
+	plflush(failedcount);
+	doreport(allcount, failedcount);
+}
+
+function dorelog(newlog) {
+	process.stdout.clearLine(0); process.stdout.cursorTo(0); process.stdout.write(newlog);
+}
+
+function doreport(rall, rfailed) {
+	console.log('');
+	console.log('Found ' + rall + ' files, ' + rfailed + ' failed.')
+}
+
+function dostatus(rcur, rall, rfailed) {
+	dorelog('Processed ' + rcur + ' of ' + rall + ' files, ' + rfailed + ' failed.');
+}
+
+function plflush(rfailed) {
+	if (!rmode) {
+		console.log(''); console.log('Writing all songs to ' + basepath + '/_all.m3u ...')
+		fs.writeFileSync(path.join(basepath, '_all.m3u'), allsongs.join('\n') + '\n', { flag: 'w+' });
+	}
+
+	var failedpath = '_failed.m3u'; if (rmode) { failedpath = '_failedagain.m3u'; }
+	if (rfailed) {
+		console.log('Writing failed songs to ' + basepath + failedpath + ' ...')
+		fs.writeFileSync(path.join(basepath, failedpath), failedsongs.join('\n') + '\n', { flag: 'w+' });
+	} else if (fs.existsSync(path.join(basepath, failedpath))) {
+		fs.unlinkSync(path.join(basepath, failedpath))
+	}
+}
+
+function plread() {
+	try {
+		console.log('Reading existing scan...')
+		if (!fs.existsSync(basepath + '/_all.m3u')) { return; }
+		allsongs = fs.readFileSync(path.join(basepath, '_all.m3u'), {encoding: 'utf-8'}).split('\n');
+		if (!allsongs[allsongs.length - 1].length) { allsongs.pop(); }
+		
+		if (!fs.existsSync(basepath + '/_failed.m3u')) { return; }
+		failedsongs = fs.readFileSync(path.join(basepath, '_failed.m3u'), {encoding: 'utf-8'}).split('\n');
+		if (!failedsongs[failedsongs.length - 1].length) { failedsongs.pop(); }
+		
+		console.log('Existing scan read (' + allsongs.length + ' all, ' + failedsongs.length + ' failed).')
+	} catch (e) {
+		console.log('Failed to read exisiting lists (' + e + ')')
+		allsongs = []
+		failedsongs = []
+	}
+}


### PR DESCRIPTION
Dear Dr. Smith,
first of all thank you for your export script! Switching from iTunes Match to Jellyfin I noticed random file corruption within my library. Therefore I've added a scanner script that checks for file presence and passes every song through ffmpeg for error detection. It generates a playlist of failed songs that is importable to iTunes for re-downloading. With all files in place I finally added a script to export all playlists as plain m3u files. I've enabled editing so you can make final adjustments.
With kind regards,
Michael Hammes